### PR TITLE
chore: remove firebase-tools from workflow

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually
   workflow_dispatch:
 
+permissions:
+  contents: read # for actions/checkout to read the repository
+
 jobs:
   deploy_next:
     if: ${{ github.repository_owner == 'koobiq' }}
@@ -17,4 +20,9 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup-node
       - run: yarn run build
-      - run: yarn firebase deploy --only hosting:next --token=${{ secrets.FIREBASE_DEPLOY_TOKEN }}
+      - uses: FirebaseExtended/action-hosting-deploy@v0.11.0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KOOBIQ }}
+          target: next
+          channelId: live # reserved channel ID for the live/production site (not a temporary preview channel)

--- a/.github/workflows/redeploy-preview.yml
+++ b/.github/workflows/redeploy-preview.yml
@@ -38,7 +38,6 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_KOOBIQ }}'
           expires: 3d
           channelId: data-grid-pr-${{ github.event.issue.number }}
-          projectId: koobiq
           target: next
       - uses: thollander/actions-comment-pull-request@v3
         if: ${{ failure() }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflows to use Firebase Hosting deployment actions.
  * Added explicit repository read permissions for deployment runs.
  * Improved preview deployments by relying on configured service credentials instead of a hard-coded project identifier.
  * Continued supporting live and pull request–specific preview channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->