### PR TITLE
fix(ag-grid-angular-theme): restore selection/focus state (#DS-5312,#DS-5046)

### DIFF
--- a/packages/ag-grid-angular-theme/src/row-focus-state.ng.ts
+++ b/packages/ag-grid-angular-theme/src/row-focus-state.ng.ts
@@ -154,8 +154,22 @@ export class KbqAgGridRowFocusState {
     /** Store used to persist and restore the active cell state. Defaults to {@link KBQ_AG_GRID_ROW_FOCUS_STATE_STORE}. */
     readonly store = input(inject(KBQ_AG_GRID_ROW_FOCUS_STATE_STORE), { alias: 'kbqAgGridRowFocusStateStore' });
 
+    private restoring = false;
+
     constructor() {
-        this.grid.gridReady.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ api }) => this.init(api));
+        this.grid.gridReady.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ api }) => this.initSave(api));
+
+        // Subscribes here, in the constructor, rather than registering a native
+        // `api.addEventListener('firstDataRendered', ...)` from inside the `gridReady` callback above.
+        // ag-grid-angular defers emitting both `gridReady` and `firstDataRendered` until after its own
+        // `ngAfterViewInit`, but only for outputs that already have a subscriber at the moment the
+        // *native* grid event fires. Since directive constructors always run before the host
+        // component's `ngAfterViewInit`, this subscription is guaranteed to be attached in time. Doing
+        // this from inside the `gridReady` callback instead is not safe: when row data is available at
+        // grid creation, the native `firstDataRendered` event fires synchronously inside `createGrid()`
+        // — before `gridReady`'s own deferred emission (and therefore this listener registration) ever
+        // runs — so the event would be missed permanently.
+        this.grid.firstDataRendered.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => void this.restore());
     }
 
     /** Removes the stored active cell state for the current key and clears grid focus. */
@@ -167,35 +181,31 @@ export class KbqAgGridRowFocusState {
         this.grid.api.clearFocusedCell();
     }
 
-    private init(api: GridApi): void {
+    private async restore(): Promise<void> {
+        const { api } = this.grid;
         const key = this.key();
         const store = this.store();
 
-        // Restoring focus needs a resolvable row index, which only exists once row nodes have
-        // actually been rendered — so this waits for `firstDataRendered` rather than `gridReady`.
-        let restoring = false;
+        const item = await store.getItem(key);
 
-        const restore: AgEventListener = () => {
-            void (async (): Promise<void> => {
-                const item = await store.getItem(key);
+        if (!item) return;
 
-                if (!item) return;
+        const node = api.getRowNode(item.rowId);
 
-                const node = api.getRowNode(item.rowId);
+        if (node?.rowIndex === null || node?.rowIndex === undefined) return;
 
-                if (node?.rowIndex === null || node?.rowIndex === undefined) return;
+        this.restoring = true;
+        api.setFocusedCell(node.rowIndex, item.colId);
+        this.restoring = false;
+    }
 
-                restoring = true;
-                api.setFocusedCell(node.rowIndex, item.colId);
-                restoring = false;
-            })();
-        };
-
-        api.addEventListener('firstDataRendered', restore);
+    private initSave(api: GridApi): void {
+        const key = this.key();
+        const store = this.store();
 
         const save: AgEventListener<unknown, unknown, 'cellFocused'> = (event) => {
             // Skips saves triggered by our own restore call to avoid redundant writes.
-            if (restoring) return;
+            if (this.restoring) return;
 
             if (event.rowIndex === null || event.column === null || event.rowPinned) {
                 void store.removeItem(key);
@@ -217,7 +227,6 @@ export class KbqAgGridRowFocusState {
         api.addEventListener('cellFocused', save);
 
         this.destroyRef.onDestroy(() => {
-            api.removeEventListener('firstDataRendered', restore);
             api.removeEventListener('cellFocused', save);
         });
     }

--- a/packages/ag-grid-angular-theme/src/row-focus-state.ng.ts
+++ b/packages/ag-grid-angular-theme/src/row-focus-state.ng.ts
@@ -155,8 +155,13 @@ export class KbqAgGridRowFocusState {
     readonly store = input(inject(KBQ_AG_GRID_ROW_FOCUS_STATE_STORE), { alias: 'kbqAgGridRowFocusStateStore' });
 
     private restoring = false;
+    private destroyed = false;
 
     constructor() {
+        this.destroyRef.onDestroy(() => {
+            this.destroyed = true;
+        });
+
         this.grid.gridReady.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ api }) => this.initSave(api));
 
         // Subscribes here, in the constructor, rather than registering a native
@@ -188,7 +193,10 @@ export class KbqAgGridRowFocusState {
 
         const item = await store.getItem(key);
 
-        if (!item) return;
+        // The store's `getItem` can be a slow, consumer-provided Promise (e.g. a network round
+        // trip) that resolves after this directive — and the grid api along with it — has already
+        // been torn down; bail out before touching either.
+        if (this.destroyed || !item) return;
 
         const node = api.getRowNode(item.rowId);
 

--- a/packages/ag-grid-angular-theme/src/row-selection-state.ng.ts
+++ b/packages/ag-grid-angular-theme/src/row-selection-state.ng.ts
@@ -151,7 +151,19 @@ export class KbqAgGridRowSelectionState {
     });
 
     constructor() {
-        this.grid.gridReady.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ api }) => this.init(api));
+        this.grid.gridReady.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ api }) => this.initSave(api));
+
+        // Subscribes here, in the constructor, rather than registering a native
+        // `api.addEventListener('firstDataRendered', ...)` from inside the `gridReady` callback above.
+        // ag-grid-angular defers emitting both `gridReady` and `firstDataRendered` until after its own
+        // `ngAfterViewInit`, but only for outputs that already have a subscriber at the moment the
+        // *native* grid event fires. Since directive constructors always run before the host
+        // component's `ngAfterViewInit`, this subscription is guaranteed to be attached in time. Doing
+        // this from inside the `gridReady` callback instead is not safe: when row data is available at
+        // grid creation, the native `firstDataRendered` event fires synchronously inside `createGrid()`
+        // — before `gridReady`'s own deferred emission (and therefore this listener registration) ever
+        // runs — so the event would be missed permanently.
+        this.grid.firstDataRendered.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => void this.restore());
     }
 
     /** Removes the stored row selection state for the current key and clears the current selection. */
@@ -163,15 +175,9 @@ export class KbqAgGridRowSelectionState {
         this.grid.api.deselectAll();
     }
 
-    private init(api: GridApi): void {
+    private initSave(api: GridApi): void {
         const key = this.key();
         const store = this.store();
-
-        const restore: AgEventListener = () => void this.restore(api, key, store);
-
-        // Row nodes only exist once data has actually been rendered, so restoring selection has
-        // to wait for `firstDataRendered` rather than running straight after `gridReady`.
-        api.addEventListener('firstDataRendered', restore);
 
         const save: AgEventListener<unknown, unknown, 'selectionChanged'> = (event) => {
             // Skips saves triggered by our own restore call to avoid redundant writes.
@@ -192,12 +198,15 @@ export class KbqAgGridRowSelectionState {
         api.addEventListener('selectionChanged', save);
 
         this.destroyRef.onDestroy(() => {
-            api.removeEventListener('firstDataRendered', restore);
             api.removeEventListener('selectionChanged', save);
         });
     }
 
-    private async restore(api: GridApi, key: string, store: KbqAgGridRowSelectionStateStore): Promise<void> {
+    private async restore(): Promise<void> {
+        const { api } = this.grid;
+        const key = this.key();
+        const store = this.store();
+
         const ids = await store.getItem(key);
         const idSet = new Set(ids ?? []);
 

--- a/packages/ag-grid-angular-theme/src/row-selection-state.ng.ts
+++ b/packages/ag-grid-angular-theme/src/row-selection-state.ng.ts
@@ -150,7 +150,13 @@ export class KbqAgGridRowSelectionState {
         alias: 'kbqAgGridRowSelectionStateStore'
     });
 
+    private destroyed = false;
+
     constructor() {
+        this.destroyRef.onDestroy(() => {
+            this.destroyed = true;
+        });
+
         this.grid.gridReady.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ api }) => this.initSave(api));
 
         // Subscribes here, in the constructor, rather than registering a native
@@ -208,6 +214,12 @@ export class KbqAgGridRowSelectionState {
         const store = this.store();
 
         const ids = await store.getItem(key);
+
+        // The store's `getItem` can be a slow, consumer-provided Promise (e.g. a network round
+        // trip) that resolves after this directive — and the grid api along with it — has already
+        // been torn down; bail out before touching either.
+        if (this.destroyed) return;
+
         const idSet = new Set(ids ?? []);
 
         // Persisted selection is the source of truth — reconcile the grid's current selection to

--- a/packages/ag-grid-angular-theme/tests/row-focus-state.ng.spec.ts
+++ b/packages/ag-grid-angular-theme/tests/row-focus-state.ng.spec.ts
@@ -61,10 +61,19 @@ const createApiMock = (
 })
 class TestAgGridAngularStub {
     readonly gridReady = new Subject<{ api: GridApi }>();
-    readonly api = createApiMock().api;
+    readonly firstDataRendered = new Subject<{ api: GridApi }>();
+    // Mirrors real ag-grid-angular, which assigns its `api` property synchronously before either
+    // output fires, so directives reading `this.grid.api` see the right instance.
+    api = createApiMock().api;
 
     emitGridReady(api: GridApi = this.api): void {
+        this.api = api;
         this.gridReady.next({ api });
+    }
+
+    emitFirstDataRendered(api: GridApi = this.api): void {
+        this.api = api;
+        this.firstDataRendered.next({ api });
     }
 }
 
@@ -104,7 +113,7 @@ describe('KbqAgGridRowFocusState', () => {
         });
 
         fixture.componentInstance.grid().emitGridReady(apiMock.api);
-        apiMock.dispatch('firstDataRendered');
+        fixture.componentInstance.grid().emitFirstDataRendered(apiMock.api);
 
         await waitFor(() => {
             expect(store.getItem).toHaveBeenCalledWith('grid-row-focus-1');
@@ -126,7 +135,7 @@ describe('KbqAgGridRowFocusState', () => {
         });
 
         fixture.componentInstance.grid().emitGridReady(apiMock.api);
-        apiMock.dispatch('firstDataRendered');
+        fixture.componentInstance.grid().emitFirstDataRendered(apiMock.api);
 
         await waitFor(() => {
             expect(store.getItem).toHaveBeenCalledWith('grid-row-focus-2');
@@ -149,7 +158,7 @@ describe('KbqAgGridRowFocusState', () => {
         });
 
         fixture.componentInstance.grid().emitGridReady(apiMock.api);
-        apiMock.dispatch('firstDataRendered');
+        fixture.componentInstance.grid().emitFirstDataRendered(apiMock.api);
 
         await waitFor(() => {
             expect(store.getItem).toHaveBeenCalledWith('grid-row-focus-3');
@@ -240,7 +249,7 @@ describe('KbqAgGridRowFocusState', () => {
         });
 
         fixture.componentInstance.grid().emitGridReady(apiMock.api);
-        apiMock.dispatch('firstDataRendered');
+        fixture.componentInstance.grid().emitFirstDataRendered(apiMock.api);
 
         await waitFor(() => {
             // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -268,7 +277,7 @@ describe('KbqAgGridRowFocusState', () => {
         expect(fixture.componentInstance.grid().api.clearFocusedCell).toHaveBeenCalled();
     });
 
-    it('removes all event listeners on destroy', async () => {
+    it('removes the cellFocused listener on destroy', async () => {
         const store: KbqAgGridRowFocusStateStore = {
             getItem: jest.fn(() => null),
             setItem: jest.fn(),
@@ -298,11 +307,29 @@ describe('KbqAgGridRowFocusState', () => {
         fixture.destroy();
 
         // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(apiMock.api.removeEventListener).toHaveBeenCalledWith(
-            'firstDataRendered',
-            getHandler('firstDataRendered')
-        );
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(apiMock.api.removeEventListener).toHaveBeenCalledWith('cellFocused', getHandler('cellFocused'));
+    });
+
+    it('stops restoring from firstDataRendered on destroy', async () => {
+        const savedValue: KbqAgGridRowFocusStateValue = { rowId: 'b', colId: 'athlete' };
+        const nodeB = makeNode('b', 1);
+        const store: KbqAgGridRowFocusStateStore = {
+            getItem: jest.fn(() => savedValue),
+            setItem: jest.fn(),
+            removeItem: jest.fn()
+        };
+        const apiMock = createApiMock({ b: nodeB });
+
+        const { fixture } = await render(TestRowFocusStateGrid, {
+            componentProperties: { key: 'grid-row-focus-9', store }
+        });
+
+        const grid = fixture.componentInstance.grid();
+
+        grid.emitGridReady(apiMock.api);
+        fixture.destroy();
+        grid.emitFirstDataRendered(apiMock.api);
+
+        expect(store.getItem).not.toHaveBeenCalled();
     });
 });

--- a/packages/ag-grid-angular-theme/tests/row-focus-state.ng.spec.ts
+++ b/packages/ag-grid-angular-theme/tests/row-focus-state.ng.spec.ts
@@ -332,4 +332,39 @@ describe('KbqAgGridRowFocusState', () => {
 
         expect(store.getItem).not.toHaveBeenCalled();
     });
+
+    it('does not touch grid focus when destroyed while store.getItem is still pending', async () => {
+        const savedValue: KbqAgGridRowFocusStateValue = { rowId: 'b', colId: 'athlete' };
+        const nodeB = makeNode('b', 1);
+        let resolveGetItem: (value: KbqAgGridRowFocusStateValue | null) => void = () => undefined;
+        const pendingItem = new Promise<KbqAgGridRowFocusStateValue | null>((resolve) => {
+            resolveGetItem = resolve;
+        });
+        const store: KbqAgGridRowFocusStateStore = {
+            getItem: jest.fn(async () => pendingItem),
+            setItem: jest.fn(),
+            removeItem: jest.fn()
+        };
+        const apiMock = createApiMock({ b: nodeB });
+
+        const { fixture } = await render(TestRowFocusStateGrid, {
+            componentProperties: { key: 'grid-row-focus-10', store }
+        });
+
+        const grid = fixture.componentInstance.grid();
+
+        grid.emitGridReady(apiMock.api);
+        grid.emitFirstDataRendered(apiMock.api);
+
+        await waitFor(() => expect(store.getItem).toHaveBeenCalledWith('grid-row-focus-10'));
+
+        // Destroy while the store's Promise is still pending — mirrors a slow, consumer-provided
+        // async store (e.g. a network round trip) resolving after the directive has torn down.
+        fixture.destroy();
+        resolveGetItem(savedValue);
+        await Promise.resolve();
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(apiMock.api.setFocusedCell).not.toHaveBeenCalled();
+    });
 });

--- a/packages/ag-grid-angular-theme/tests/row-selection-state.ng.spec.ts
+++ b/packages/ag-grid-angular-theme/tests/row-selection-state.ng.spec.ts
@@ -64,10 +64,19 @@ const createApiMock = (
 })
 class TestAgGridAngularStub {
     readonly gridReady = new Subject<{ api: GridApi }>();
-    readonly api = createApiMock().api;
+    readonly firstDataRendered = new Subject<{ api: GridApi }>();
+    // Mirrors real ag-grid-angular, which assigns its `api` property synchronously before either
+    // output fires, so directives reading `this.grid.api` see the right instance.
+    api = createApiMock().api;
 
     emitGridReady(api: GridApi = this.api): void {
+        this.api = api;
         this.gridReady.next({ api });
+    }
+
+    emitFirstDataRendered(api: GridApi = this.api): void {
+        this.api = api;
+        this.firstDataRendered.next({ api });
     }
 }
 
@@ -107,7 +116,7 @@ describe('KbqAgGridRowSelectionState', () => {
         });
 
         fixture.componentInstance.grid().emitGridReady(apiMock.api);
-        apiMock.dispatch('firstDataRendered');
+        fixture.componentInstance.grid().emitFirstDataRendered(apiMock.api);
 
         await waitFor(() => {
             expect(store.getItem).toHaveBeenCalledWith('grid-row-selection-1');
@@ -138,7 +147,7 @@ describe('KbqAgGridRowSelectionState', () => {
         });
 
         fixture.componentInstance.grid().emitGridReady(apiMock.api);
-        apiMock.dispatch('firstDataRendered');
+        fixture.componentInstance.grid().emitFirstDataRendered(apiMock.api);
 
         await waitFor(() => {
             expect(nodeA.isSelected()).toBe(false);
@@ -160,7 +169,7 @@ describe('KbqAgGridRowSelectionState', () => {
         });
 
         fixture.componentInstance.grid().emitGridReady(apiMock.api);
-        apiMock.dispatch('firstDataRendered');
+        fixture.componentInstance.grid().emitFirstDataRendered(apiMock.api);
 
         await waitFor(() => {
             expect(nodeA.isSelected()).toBe(false);
@@ -181,7 +190,7 @@ describe('KbqAgGridRowSelectionState', () => {
         });
 
         fixture.componentInstance.grid().emitGridReady(apiMock.api);
-        apiMock.dispatch('firstDataRendered');
+        fixture.componentInstance.grid().emitFirstDataRendered(apiMock.api);
 
         await waitFor(() => {
             expect(store.getItem).toHaveBeenCalledWith('grid-row-selection-2');
@@ -291,7 +300,7 @@ describe('KbqAgGridRowSelectionState', () => {
         expect(fixture.componentInstance.grid().api.deselectAll).toHaveBeenCalled();
     });
 
-    it('removes all event listeners on destroy', async () => {
+    it('removes the selectionChanged listener on destroy', async () => {
         const store: KbqAgGridRowSelectionStateStore = {
             getItem: jest.fn(() => null),
             setItem: jest.fn(),
@@ -322,13 +331,30 @@ describe('KbqAgGridRowSelectionState', () => {
 
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(apiMock.api.removeEventListener).toHaveBeenCalledWith(
-            'firstDataRendered',
-            getHandler('firstDataRendered')
-        );
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(apiMock.api.removeEventListener).toHaveBeenCalledWith(
             'selectionChanged',
             getHandler('selectionChanged')
         );
+    });
+
+    it('stops restoring from firstDataRendered on destroy', async () => {
+        const nodeB = makeNode('b');
+        const store: KbqAgGridRowSelectionStateStore = {
+            getItem: jest.fn(() => ['b']),
+            setItem: jest.fn(),
+            removeItem: jest.fn()
+        };
+        const apiMock = createApiMock([nodeB]);
+
+        const { fixture } = await render(TestRowSelectionStateGrid, {
+            componentProperties: { key: 'grid-row-selection-8', store }
+        });
+
+        const grid = fixture.componentInstance.grid();
+
+        grid.emitGridReady(apiMock.api);
+        fixture.destroy();
+        grid.emitFirstDataRendered(apiMock.api);
+
+        expect(store.getItem).not.toHaveBeenCalled();
     });
 });

--- a/packages/ag-grid-angular-theme/tests/row-selection-state.ng.spec.ts
+++ b/packages/ag-grid-angular-theme/tests/row-selection-state.ng.spec.ts
@@ -357,4 +357,38 @@ describe('KbqAgGridRowSelectionState', () => {
 
         expect(store.getItem).not.toHaveBeenCalled();
     });
+
+    it('does not touch grid selection when destroyed while store.getItem is still pending', async () => {
+        const nodeB = makeNode('b');
+        let resolveGetItem: (value: string[] | null) => void = () => undefined;
+        const pendingItem = new Promise<string[] | null>((resolve) => {
+            resolveGetItem = resolve;
+        });
+        const store: KbqAgGridRowSelectionStateStore = {
+            getItem: jest.fn(async () => pendingItem),
+            setItem: jest.fn(),
+            removeItem: jest.fn()
+        };
+        const apiMock = createApiMock([nodeB]);
+
+        const { fixture } = await render(TestRowSelectionStateGrid, {
+            componentProperties: { key: 'grid-row-selection-9', store }
+        });
+
+        const grid = fixture.componentInstance.grid();
+
+        grid.emitGridReady(apiMock.api);
+        grid.emitFirstDataRendered(apiMock.api);
+
+        await waitFor(() => expect(store.getItem).toHaveBeenCalledWith('grid-row-selection-9'));
+
+        // Destroy while the store's Promise is still pending — mirrors a slow, consumer-provided
+        // async store (e.g. a network round trip) resolving after the directive has torn down.
+        fixture.destroy();
+        resolveGetItem(['b']);
+        await Promise.resolve();
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(apiMock.api.setNodesSelected).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
#195 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration of saved row focus and selection when grid data is first rendered.
  * Prevented focus or selection restoration after the grid component has been destroyed.
  * Preserved correct behavior when restoring, clearing, or skipping saved selections.

* **Tests**
  * Expanded coverage for first-render restoration and component-destruction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->