### PR TITLE
chore: fix e2e test after playwright update

### DIFF
--- a/dev/ag-grid-angular/src/tests/theme.playwright-spec.ts
+++ b/dev/ag-grid-angular/src/tests/theme.playwright-spec.ts
@@ -62,9 +62,13 @@ test.describe('KbqAgGridAngularTheme', () => {
     test('with opened filter popup', async ({ page }) => {
         await page.setViewportSize({ width: 768, height: 500 });
         await page.goto('/e2e/theme');
+        // Wait for async row data and the generated selection column before capturing the grid.
+        await page.locator('.ag-row[row-index]').first().waitFor();
+        await page.getByRole('checkbox', { name: 'Column with Header Selection' }).waitFor();
         await page.locator('.ag-header-cell[col-id="athlete"]').hover();
         await page.locator('.ag-header-cell[col-id="athlete"] .ag-header-cell-filter-button').click();
         await page.locator('.ag-menu .ag-filter-select').click();
+        await page.getByRole('option', { name: 'Contains', exact: true }).waitFor();
         await expect(getScreenshotTarget(page)).toHaveScreenshot('theme-filter-popup-light.png');
         await enableDarkTheme(page);
         await expect(getScreenshotTarget(page)).toHaveScreenshot('theme-filter-popup-dark.png');

--- a/dev/ag-grid-angular/src/tests/theme.playwright-spec.ts
+++ b/dev/ag-grid-angular/src/tests/theme.playwright-spec.ts
@@ -64,7 +64,7 @@ test.describe('KbqAgGridAngularTheme', () => {
         await page.goto('/e2e/theme');
         // Wait for async row data and the generated selection column before capturing the grid.
         await page.locator('.ag-row[row-index]').first().waitFor();
-        await page.getByRole('checkbox', { name: 'Column with Header Selection' }).waitFor();
+        await page.locator('.ag-header-cell input[type="checkbox"]').first().waitFor();
         await page.locator('.ag-header-cell[col-id="athlete"]').hover();
         await page.locator('.ag-header-cell[col-id="athlete"] .ag-header-cell-filter-button').click();
         await page.locator('.ag-menu .ag-filter-select').click();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved filter popup visual testing by waiting for row data, selection controls, and filter options to load before capturing screenshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->